### PR TITLE
Must set CWD when running NVM or git

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -76,6 +76,7 @@ class nvm (
   if $install_node {
     nvm::node::install { $install_node:
       user    => $user,
+      home    => $home,
       nvm_dir => $nvm_dir,
       default => true,
     }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -47,6 +47,7 @@ class nvm (
 
   class { 'nvm::install':
     user         => $user,
+    home         => $home,
     version      => $version,
     nvm_dir      => $nvm_dir,
     nvm_repo     => $nvm_repo,

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -1,6 +1,7 @@
 # See README.md for usage information
 class nvm::install (
   $user,
+  $home,
   $version,
   $nvm_dir,
   $nvm_repo,
@@ -10,7 +11,7 @@ class nvm::install (
 
   exec { "git clone ${nvm_repo} ${nvm_dir}":
     command => "git clone ${nvm_repo} ${nvm_dir}",
-    cwd     => $nvm::home,
+    cwd     => $home,
     user    => $user,
     unless  => "test -d ${nvm_dir}/.git",
     require => $dependencies,

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -10,10 +10,11 @@ class nvm::install (
 
   exec { "git clone ${nvm_repo} ${nvm_dir}":
     command => "git clone ${nvm_repo} ${nvm_dir}",
+    cwd     => $nvm::home,
     user    => $user,
     unless  => "test -d ${nvm_dir}/.git",
     require => $dependencies,
-    notify  => Exec["git checkout ${nvm_repo} ${version}"]
+    notify  => Exec["git checkout ${nvm_repo} ${version}"],
   }
 
   if $refetch {

--- a/manifests/node/install.pp
+++ b/manifests/node/install.pp
@@ -1,6 +1,7 @@
 # See README.md for usage information
 define nvm::node::install (
   $user,
+  $home        = "/home/${user}",
   $nvm_dir     = "/home/${user}/.nvm",
   $version     = $title,
   $default     = false,
@@ -26,7 +27,8 @@ define nvm::node::install (
   }
 
   exec { "nvm install node version ${version}":
-    command     => ". ${nvm_dir}/nvm.sh && nvm install ${nvm_install_options} ${version}",
+    command     => "/bin/bash -c '. ${nvm_dir}/nvm.sh && nvm install ${nvm_install_options} ${version}' && env",
+    cwd         => $home,
     user        => $user,
     unless      => ". ${nvm_dir}/nvm.sh && nvm which ${version}",
     environment => [ "NVM_DIR=${nvm_dir}" ],
@@ -37,6 +39,7 @@ define nvm::node::install (
   if $default {
     exec { "nvm set node version ${version} as default":
       command     => ". ${nvm_dir}/nvm.sh && nvm alias default ${version}",
+      cwd         => $home,
       user        => $user,
       environment => [ "NVM_DIR=${nvm_dir}" ],
       unless      => ". ${nvm_dir}/nvm.sh && nvm which default | grep ${version}",


### PR DESCRIPTION
Otherwise, `git clone` fails, as the user usually does not have access to `root` user $HOME.
Same for NVM, which fails to list any NVMs or install:

```
Info: Applying configuration version '1455454955'
Notice: /Stage[main]/Nvm/Nvm::Node::Install[5.6.0]/Exec[nvm install node version 5.6.0]/returns: Error: EACCES: permission denied, scandir '/root'
Notice: /Stage[main]/Nvm/Nvm::Node::Install[5.6.0]/Exec[nvm install node version 5.6.0]/returns:     at Error (native)
Notice: /Stage[main]/Nvm/Nvm::Node::Install[5.6.0]/Exec[nvm install node version 5.6.0]/returns: 
Notice: /Stage[main]/Nvm/Nvm::Node::Install[5.6.0]/Exec[nvm install node version 5.6.0]/returns: Error: EACCES: permission denied, open 'npm-debug.log.669455593'
Notice: /Stage[main]/Nvm/Nvm::Node::Install[5.6.0]/Exec[nvm install node version 5.6.0]/returns:     at Error (native)
Notice: /Stage[main]/Nvm/Nvm::Node::Install[5.6.0]/Exec[nvm install node version 5.6.0]/returns: 
Notice: /Stage[main]/Nvm/Nvm::Node::Install[5.6.0]/Exec[nvm install node version 5.6.0]/returns: nvm is not compatible with the npm config "prefix" option: currently set to ""
Notice: /Stage[main]/Nvm/Nvm::Node::Install[5.6.0]/Exec[nvm install node version 5.6.0]/returns: Run `nvm use --delete-prefix v5.6.0 --silent` to unset it.
Error: /bin/bash -c '. /home/deployer/.nvm/nvm.sh && nvm install  5.6.0' returned 11 instead of one of [0]
```
