### PR TITLE
Add node_instances parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,34 @@
-## 2015-11-11 - v1.0.0
+# Change Log for puppet module artberri-nvm
+
+## ?? - v1.1.0
+
 ### Summary
+
+Ability to install multiple node.js instances with a new parameter.
+Minor fixes.
+
+#### Features/Improvements
+
+- New parameter `node_instances` in the `nvm` class accepts a hash for installing multiple node.js instances
+
+#### Deprecated params
+
+- The `default` parameter in the define `nvm::node::install` is now deprecated because [is a reserved word](https://docs.puppetlabs.com/puppet/latest/reference/lang_reserved.html#reserved-words), use `set_default` instead. Backguard compatibilty is added but throws a warning message.
+
+#### Fixes
+
+- All `exec` calls set now a `cwd` param
+- Rspec and Beaker tests improved
+
+## 2015-11-11 - v1.0.0
+
+### Summary
+
 After being tested in a production server this module leaves the beta state.
 This version include also the first acceptance tests.
 
-####Features/Improvements
+#### Features/Improvements
+
 - README.md and CONTRIBUTING.md file improvements and fixes
 - Acceptance tests included
 - Examples added

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ class { 'nvm':
 
 nvm::node::install { '0.12.7':
     user    => 'foo',
-    default => true,
+    set_default => true,
 } ->
 
 nvm::node::install { '0.10.36':
@@ -87,6 +87,21 @@ nvm::node::install { '0.10.36':
 
 nvm::node::install { 'iojs':
     user => 'foo',
+}
+```
+
+Or:
+
+```puppet
+class { 'nvm':
+  user           => 'foo',
+  node_instances => {
+    '0.12.7' => {
+      set_default => true,
+    },
+    '0.10.36' => {},
+    'iojs' => {},
+  }
 }
 ```
 
@@ -213,6 +228,12 @@ Installs a default Node.js version. Could be set to any NVM Node.js version name
 
 Default: `undef`.
 
+#### `node_instances`
+
+A hash with the node instances you want to install (it will be used to create `nvm::node::install` instances with `create_resources`).
+
+Default: {}.
+
 ### Define: `nvm::node::install`
 
 Installs a Node.js version.
@@ -235,7 +256,13 @@ Node.js version. Could be set to any NVM Node.js version name.
 
 Default: `0.12.7`.
 
-#### `default`
+#### `set_default` *[Since version 1.1.0]*
+
+Determines whether to set this Node.js version as default.
+
+#### `default` *[Deprecated since version 1.1.0 use `set_default` instead]*
+
+This parameter is now deprecated because [is a reserved word](https://docs.puppetlabs.com/puppet/latest/reference/lang_reserved.html#reserved-words), use `set_default` instead. Backguard compatibilty is added but throws a warning message.
 
 Determines whether to set this Node.js version as default.
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -11,6 +11,7 @@ class nvm (
   $nvm_repo            = $nvm::params::nvm_repo,
   $refetch             = $nvm::params::refetch,
   $install_node        = $nvm::params::install_node,
+  $node_instances      = $nvm::params::node_instances,
 ) inherits ::nvm::params {
 
   if $home == undef and $user == 'root' {
@@ -48,6 +49,7 @@ class nvm (
   if $install_node {
     validate_string($install_node)
   }
+  validate_hash($node_instances)
 
   Exec {
     path => '/bin:/sbin:/usr/bin:/usr/sbin',
@@ -99,11 +101,19 @@ class nvm (
   }
 
   if $install_node {
-    nvm::node::install { $install_node:
-      user    => $user,
-      nvm_dir => $final_nvm_dir,
-      default => true,
-    }
+    $final_node_instances = merge($node_instances, {
+      "${install_node}" => {
+        set_default => true,
+      },
+    })
   }
+  else {
+    $final_node_instances = $node_instances
+  }
+
+  create_resources(::nvm::node::install, $final_node_instances, {
+    user        => $user,
+    nvm_dir     => $final_nvm_dir,
+  })
 
 }

--- a/manifests/node/install.pp
+++ b/manifests/node/install.pp
@@ -3,13 +3,23 @@ define nvm::node::install (
   $user,
   $nvm_dir     = undef,
   $version     = $title,
-  $default     = false,
+  $set_default = false,
   $from_source = false,
+  $default     = false,
 ) {
 
   # The base class must be included first because it is used by parameter defaults
   if ! defined(Class['nvm']) {
     fail('You must include the nvm base class before using any nvm defined resources')
+  }
+
+  # Notify users that uses the deprecated default parameter
+  if $default {
+    notify { 'The `default` parameter is now deprecated because is a reserved word use `set_default` instead': }
+    $is_default = true
+  }
+  else {
+    $is_default = $set_default
   }
 
   if $nvm_dir == undef {
@@ -23,6 +33,7 @@ define nvm::node::install (
   validate_string($final_nvm_dir)
   validate_string($version)
   validate_bool($default)
+  validate_bool($set_default)
   validate_bool($from_source)
 
   if $from_source {
@@ -42,7 +53,7 @@ define nvm::node::install (
     provider    => shell,
   }
 
-  if $default {
+  if $is_default {
     exec { "nvm set node version ${version} as default":
       cwd         => $final_nvm_dir,
       command     => ". ${final_nvm_dir}/nvm.sh && nvm alias default ${version}",

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -7,4 +7,5 @@ class nvm::params {
   $nvm_repo            = 'https://github.com/creationix/nvm.git'
   $refetch             = false
   $install_node        = undef
+  $node_instances      = {}
 }

--- a/spec/acceptance/01_backwards_compatibility.rb
+++ b/spec/acceptance/01_backwards_compatibility.rb
@@ -5,17 +5,13 @@ describe 'nvm::node::install define' do
   describe 'running puppet code' do
     pp = <<-EOS
         class { 'nvm':
-            user        => 'foo',
+            user        => 'bar',
             manage_user => true,
         }
 
-        nvm::node::install { '4.3.1':
-            user    => 'foo',
+        nvm::node::install { '5.6.0':
+            user    => 'bar',
             default => true,
-        }
-
-        nvm::node::install { '0.10.40':
-            user    => 'foo',
         }
     EOS
     let(:manifest) { pp }
@@ -24,8 +20,8 @@ describe 'nvm::node::install define' do
       apply_manifest(manifest, :catch_failures => true)
     end
 
-    it 'should be idempotent' do
-      apply_manifest(manifest, :catch_changes => true)
+    it 'should not be idempotent and should throw a deprection warning' do
+      apply_manifest(manifest, :expect_changes => true)
     end
 
     describe command('su - foo -c ". /home/foo/.nvm/nvm.sh && nvm --version" -s /bin/bash') do
@@ -35,12 +31,7 @@ describe 'nvm::node::install define' do
 
     describe command('su - foo -c ". /home/foo/.nvm/nvm.sh && node --version" -s /bin/bash') do
       its(:exit_status) { should eq 0 }
-      its(:stdout) { should match /4.3.1/ }
-    end
-
-    describe command('su - foo -c ". /home/foo/.nvm/nvm.sh && nvm ls" -s /bin/bash') do
-      its(:exit_status) { should eq 0 }
-      its(:stdout) { should match /0.10.40/ }
+      its(:stdout) { should match /5.6.0/ }
     end
 
   end

--- a/spec/acceptance/02_nvm_node_install_spec.rb
+++ b/spec/acceptance/02_nvm_node_install_spec.rb
@@ -1,0 +1,48 @@
+require 'spec_helper_acceptance'
+
+describe 'nvm::node::install define' do
+
+  describe 'running puppet code' do
+    pp = <<-EOS
+        class { 'nvm':
+            user        => 'foo',
+            manage_user => true,
+        }
+
+        nvm::node::install { '4.3.1':
+            user        => 'foo',
+            set_default => true,
+        }
+
+        nvm::node::install { '0.10.40':
+            user    => 'foo',
+        }
+    EOS
+    let(:manifest) { pp }
+
+    it 'should work with no errors' do
+      apply_manifest(manifest, :catch_failures => true)
+    end
+
+    it 'should be idempotent' do
+      apply_manifest(manifest, :catch_changes => true)
+    end
+
+    describe command('su - foo -c ". /home/foo/.nvm/nvm.sh && nvm --version" -s /bin/bash') do
+      its(:exit_status) { should eq 0 }
+      its(:stdout) { should match /0.29.0/ }
+    end
+
+    describe command('su - foo -c ". /home/foo/.nvm/nvm.sh && node --version" -s /bin/bash') do
+      its(:exit_status) { should eq 0 }
+      its(:stdout) { should match /4.3.1/ }
+    end
+
+    describe command('su - foo -c ". /home/foo/.nvm/nvm.sh && nvm ls" -s /bin/bash') do
+      its(:exit_status) { should eq 0 }
+      its(:stdout) { should match /0.10.40/ }
+    end
+
+  end
+
+end

--- a/spec/acceptance/03_nvm_spec.rb
+++ b/spec/acceptance/03_nvm_spec.rb
@@ -5,11 +5,15 @@ describe 'nvm class' do
   describe 'running puppet code' do
     pp = <<-EOS
       class { 'nvm':
-        user => 'root',
-        nvm_dir => '/opt/nvm',
-        version => 'v0.29.0',
-        profile_path => '/etc/profile.d/nvm.sh',
-        install_node => '0.12.7',
+        user           => 'root',
+        nvm_dir        => '/opt/nvm',
+        version        => 'v0.29.0',
+        profile_path   => '/etc/profile.d/nvm.sh',
+        install_node   => '0.12.7',
+        node_instances => {
+          '0.10.36' => {},
+          '4.0.0' => {},
+        },
       }
     EOS
     let(:manifest) { pp }
@@ -30,6 +34,16 @@ describe 'nvm class' do
     describe command('. /etc/profile.d/nvm.sh && node --version') do
       its(:exit_status) { should eq 0 }
       its(:stdout) { should match /0.12.7/ }
+    end
+
+    describe command('. /etc/profile.d/nvm.sh && nvm ls') do
+      its(:exit_status) { should eq 0 }
+      its(:stdout) { should match /0.10.36/ }
+    end
+
+    describe command('. /etc/profile.d/nvm.sh && nvm ls') do
+      its(:exit_status) { should eq 0 }
+      its(:stdout) { should match /4.0.0/ }
     end
 
   end

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -111,7 +111,28 @@ describe 'nvm', :type => :class do
     it { should contain_nvm__node__install('dummyversion')
                     .with_user('foo')
                     .with_nvm_dir('/home/foo/.nvm')
-                    .with_default(true)
+                    .with_set_default(true)
+    }
+  end
+
+  context 'with multiple node_instances' do
+    let :params do
+    {
+      :user => 'foo',
+      :node_instances => {
+          '0.10.40' => {},
+          '0.12.7'  => {},
+      }
+    }
+    end
+
+    it { should contain_nvm__node__install('0.10.40')
+                    .with_user('foo')
+                    .with_nvm_dir('/home/foo/.nvm')
+    }
+    it { should contain_nvm__node__install('0.12.7')
+                    .with_user('foo')
+                    .with_nvm_dir('/home/foo/.nvm')
     }
   end
 


### PR DESCRIPTION
- `node_instances` parameter added for hiera support or other uses (Foreman,...). Iplements the suggestion in #3 
- Changes the `default` parameter with `set_default` in `nvm::node::install` because is a reserved word. It keeps backward compatibility.
