### PR TITLE
Remove dependency on stdlibs

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -38,19 +38,6 @@ class nvm (
     $final_profile_path = $profile_path
   }
 
-  validate_string($user)
-  validate_string($final_home)
-  validate_string($final_nvm_dir)
-  validate_string($final_profile_path)
-  validate_string($version)
-  validate_bool($manage_user)
-  validate_bool($manage_dependencies)
-  validate_bool($manage_profile)
-  if $install_node {
-    validate_string($install_node)
-  }
-  validate_hash($node_instances)
-
   Exec {
     path => '/bin:/sbin:/usr/bin:/usr/sbin',
   }

--- a/manifests/node/install.pp
+++ b/manifests/node/install.pp
@@ -29,13 +29,6 @@ define nvm::node::install (
     $final_nvm_dir = $nvm_dir
   }
 
-  validate_string($user)
-  validate_string($final_nvm_dir)
-  validate_string($version)
-  validate_bool($default)
-  validate_bool($set_default)
-  validate_bool($from_source)
-
   if $from_source {
     $nvm_install_options = ' -s '
   }


### PR DESCRIPTION
The module fails when using stdlibs version 9.3.0 because the validate_ functions have been deprecated. 

The module is still functional without these validations.