### PR TITLE
Fix issues with legacy validation and newer versions of Puppet

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -87,14 +87,14 @@ class nvm (
       ensure => 'present',
       path   => $final_profile_path,
       owner  => $user,
-    } ->
+    }
 
-    file_line { 'add NVM_DIR to profile file':
+    -> file_line { 'add NVM_DIR to profile file':
       path => $final_profile_path,
       line => "export NVM_DIR=${final_nvm_dir}",
-    } ->
+    }
 
-    file_line { 'add . ~/.nvm/nvm.sh to profile file':
+    -> file_line { 'add . ~/.nvm/nvm.sh to profile file':
       path => $final_profile_path,
       line => "[ -s \"\$NVM_DIR/nvm.sh\" ] && . \"\$NVM_DIR/nvm.sh\"  # This loads nvm",
     }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,9 +1,10 @@
 # See README.md for usage information
 class nvm (
-  $user,
-  $home                = undef,
-  $nvm_dir             = undef,
-  $profile_path        = undef,
+  String           $user,
+  Optional[String] $home                = undef,
+  Optional[String] $nvm_dir             = undef,
+  Optional[String] $profile_path        = undef,
+
   $version             = $nvm::params::version,
   $manage_user         = $nvm::params::manage_user,
   $manage_dependencies = $nvm::params::manage_dependencies,
@@ -37,19 +38,6 @@ class nvm (
   else {
     $final_profile_path = $profile_path
   }
-
-  validate_legacy(String, 'validate_string', $user)
-  validate_legacy(String, 'validate_string', $final_home)
-  validate_legacy(String, 'validate_string', $final_nvm_dir)
-  validate_legacy(String, 'validate_string', $final_profile_path)
-  validate_legacy(String, 'validate_string', $version)
-  validate_legacy(Boolean, 'validate_bool', $manage_user)
-  validate_legacy(Boolean, 'validate_bool', $manage_dependencies)
-  validate_legacy(Boolean, 'validate_bool', $manage_profile)
-  if $install_node {
-    validate_legacy(String, 'validate_string', $install_node)
-  }
-  validate_legacy(Hash, 'validate_hash', $node_instances)
 
   Exec {
     path => '/bin:/sbin:/usr/bin:/usr/sbin',

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -38,18 +38,18 @@ class nvm (
     $final_profile_path = $profile_path
   }
 
-  validate_string($user)
-  validate_string($final_home)
-  validate_string($final_nvm_dir)
-  validate_string($final_profile_path)
-  validate_string($version)
-  validate_bool($manage_user)
-  validate_bool($manage_dependencies)
-  validate_bool($manage_profile)
+  validate_legacy(String, 'validate_string', $user)
+  validate_legacy(String, 'validate_string', $final_home)
+  validate_legacy(String, 'validate_string', $final_nvm_dir)
+  validate_legacy(String, 'validate_string', $final_profile_path)
+  validate_legacy(String, 'validate_string', $version)
+  validate_legacy(Boolean, 'validate_bool', $manage_user)
+  validate_legacy(Boolean, 'validate_bool', $manage_dependencies)
+  validate_legacy(Boolean, 'validate_bool', $manage_profile)
   if $install_node {
-    validate_string($install_node)
+    validate_legacy(String, 'validate_string', $install_node)
   }
-  validate_hash($node_instances)
+  validate_legacy(Hash, 'validate_hash', $node_instances)
 
   Exec {
     path => '/bin:/sbin:/usr/bin:/usr/sbin',

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -1,12 +1,12 @@
 # See README.md for usage information
 class nvm::install (
-  $user,
-  $home,
-  $version,
-  $nvm_dir,
-  $nvm_repo,
-  $dependencies,
-  $refetch,
+  String  $user,
+  String  $home,
+  String  $version,
+  String  $nvm_dir,
+  String  $nvm_repo,
+  Array   $dependencies,
+  Boolean $refetch,
 ) {
 
   exec { "git clone ${nvm_repo} ${nvm_dir}":

--- a/manifests/node/install.pp
+++ b/manifests/node/install.pp
@@ -29,12 +29,12 @@ define nvm::node::install (
     $final_nvm_dir = $nvm_dir
   }
 
-  validate_string($user)
-  validate_string($final_nvm_dir)
-  validate_string($version)
-  validate_bool($default)
-  validate_bool($set_default)
-  validate_bool($from_source)
+  validate_legacy(String, 'validate_string', $user)
+  validate_legacy(String, 'validate_string', $final_nvm_dir)
+  validate_legacy(String, 'validate_string', $version)
+  validate_legacy(Boolean, 'validate_bool', $default)
+  validate_legacy(Boolean, 'validate_bool', $set_default)
+  validate_legacy(Boolean, 'validate_bool', $from_source)
 
   if $from_source {
     $nvm_install_options = ' -s '

--- a/manifests/node/install.pp
+++ b/manifests/node/install.pp
@@ -1,11 +1,11 @@
 # See README.md for usage information
 define nvm::node::install (
-  $user,
-  $nvm_dir     = undef,
-  $version     = $title,
-  $set_default = false,
-  $from_source = false,
-  $default     = false,
+  String           $user,
+  Optional[String] $nvm_dir     = undef,
+  String           $version     = $title,
+  Boolean          $set_default = false,
+  Boolean          $from_source = false,
+  Boolean          $default     = false,
 ) {
 
   # The base class must be included first because it is used by parameter defaults
@@ -28,13 +28,6 @@ define nvm::node::install (
   else {
     $final_nvm_dir = $nvm_dir
   }
-
-  validate_legacy(String, 'validate_string', $user)
-  validate_legacy(String, 'validate_string', $final_nvm_dir)
-  validate_legacy(String, 'validate_string', $version)
-  validate_legacy(Boolean, 'validate_bool', $default)
-  validate_legacy(Boolean, 'validate_bool', $set_default)
-  validate_legacy(Boolean, 'validate_bool', $from_source)
 
   if $from_source {
     $nvm_install_options = ' -s '

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "artberri-nvm",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "author": "artberri",
   "summary": "Puppet Module to install Node.js with Node Version Manager (NVM)",
   "description": "A puppet module to install (multiple versions of) Node.js with NVM (Node Version Manager).",
@@ -60,17 +60,13 @@
   "dependencies": [
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">=3.2.0 <5.0.0"
+      "version_requirement": ">=4.13.0"
     }
   ],
   "requirements": [
     {
-      "name": "pe",
-      "version_requirement": "3.x"
-    },
-    {
       "name": "puppet",
-      "version_requirement": ">=2.7.20 <5.0.0"
+      "version_requirement": ">=4.13.0"
     }
   ]
 }


### PR DESCRIPTION
Similar to https://github.com/artberri/puppet-nvm/pull/23 but it takes a different approach and keeps the validation but uses the newer Puppet's `validate_legacy` function.